### PR TITLE
Zmiana sortowanie, dodanie dat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,44 +1,50 @@
-| Nazwa | Miasto | Następne | Strona | Nagrania |
+| Nazwa | Miasto | Data | Strona | Nagrania |
 |----------|:-------------:|:------|:------|:------|
-| Pyrcode	| Poznań	| 2019-01-18	| [link](https://pyrcode.pl)	|  |
-| KarieraIT	| Wrocław	| 2019-02-16	| 	|  |
-| Lambda Days	| Kraków	| 2019-02-21 - 2019-02-22	| [link](http://www.lambdadays.org/)	| [link](https://www.youtube.com/watch?v=RCU5WQDT8_8&list=PLWbHc_FXPo2jaxwnNB7KFEV7HYA0qHVxl) |
-| KarieraIT	| Gdańsk	| 2019-03-02	| 	|  |
-| SegFault	| Gdańsk	| 2019-03-14 - 2019-03-15	| [link](http://segfault.events/)	| [link](https://www.youtube.com/channel/UCV38Do_3C5uVk3lWePkyxTA/videos) |
-| KarieraIT	| Warszawa	| 2019-03-16	| 	|  |
-| SFI	| Kraków	| 2019-03-21 - 2019-03-23	| [link](https://sfi.pl/)	| [link](https://www.youtube.com/user/StudenckiFestiwalInf/videos) |
-| KarieraIT	| Łódź	| 2019-03-23	| 	|  |
-| AzureDay Poland	| Warszawa	| 2019-03-29	| [link](http://azureday.pro/)	|  |
-| Wroc#	| Wrocław	| 2019-03-29	| [link](https://www.wrocsharp.com/)	| [link](https://www.youtube.com/channel/UCQBldPvCFyB7GECmEsXKBlw/videos) |
-| Boiling Frogs	| Wrocław	| 2019-03-30	| [link](https://2019.boilingfrogs.pl/)	| [link](https://www.youtube.com/channel/UCgUfIjfLvWmARsQ-d5gPzrw/videos) |
-| 4Developers	| Warszawa	| 2019-04-08	| [link](https://4developers.org.pl/)	| [link](https://www.youtube.com/user/PROIDEAconferences/playlists?sort=dd&shelf_id=13&view=50) |
-| KarieraIT	| Rzeszów	| 2019-04-13	| 	|  |
-| SegFault	| Łódź	| 2019-04-26	| [link](http://segfault.events/)	|  |
-| infoShare	| Gdańsk	| 2019-05-08 - 2019-05-08	| [link](https://infoshare.pl/)	| [link](https://www.youtube.com/user/infoSharePL/playlists) |
-| KarieraIT	| Katowice	| 2019-05-11	| 	|  |
-| GeeCON	| Kraków	| 2019-05-15 - 2019-05-17	| [link](https://geecon.org/)	| [link](https://www.youtube.com/channel/UCVnJYdr91EZW8YvtMrxB1bg/videos) |
-| KarieraIT	| Poznań	| 2019-05-25	| 	|  |
-| Cloud Developer Days	| Warszawa	| 2019-05-27 - 2019-05-29	| [link](http://cloud.developerdays.pl/)	|  |
-| Confidence	| Kraków	| 2019-06-03 - 2019-06-04	| [link](https://confidence-conference.org/)	| [link](https://www.youtube.com/user/PROIDEAconferences/playlists?sort=dd&shelf_id=8&view=50) |
-| KarieraIT	| Kraków	| 2019-06-08	| 	|  |
-| Devoxx	| Kraków	| 2019-06-24 - 2019-06-27	| [link](http://devoxx.pl/)	| [link](https://www.youtube.com/watch?v=5VFOYM6DlJc&list=PLRsbF2sD7JVqYR6LI7atNZFvVKyAC1lwH) |
-| DevConf	| Kraków	| 2019-09-25 - 2019-09-27	| [link](http://devconf.pl)	| [link](https://www.youtube.com/channel/UCXp2tbIOcFe0WP1OaoREmWA/videos) |
-| Sphere.it	| Kraków	| 2019-10-06 - 2019-10-09	| [link](https://sphere.it/)	|  |
 | .NET Developer Days	| Warszawa	| 2019-10-23 - 2019-10-25	| [link](http://net.developerdays.pl/)	| [link](https://www.youtube.com/channel/UC_oRRPZrYP4gZQOJOcuTyUw/videos) |
-| {j}dd	| Kraków	| 	| [link](https://www.jdd.org.pl)	|  |
+| Sphere.it	| Kraków	| 2019-10-06 - 2019-10-09	| [link](https://sphere.it/)	|  |
+| DevConf	| Kraków	| 2019-09-25 - 2019-09-27	| [link](http://devconf.pl)	| [link](https://www.youtube.com/channel/UCXp2tbIOcFe0WP1OaoREmWA/videos) |
+| Devoxx	| Kraków	| 2019-06-24 - 2019-06-27	| [link](http://devoxx.pl/)	| [link](https://www.youtube.com/watch?v=5VFOYM6DlJc&list=PLRsbF2sD7JVqYR6LI7atNZFvVKyAC1lwH) |
+| KarieraIT	| Kraków	| 2019-06-08	| 	|  |
+| Confidence	| Kraków	| 2019-06-03 - 2019-06-04	| [link](https://confidence-conference.org/)	| [link](https://www.youtube.com/user/PROIDEAconferences/playlists?sort=dd&shelf_id=8&view=50) |
+| Cloud Developer Days	| Warszawa	| 2019-05-27 - 2019-05-29	| [link](http://cloud.developerdays.pl/)	|  |
+| KarieraIT	| Poznań	| 2019-05-25	| 	|  |
+| GeeCON	| Kraków	| 2019-05-15 - 2019-05-17	| [link](https://geecon.org/)	| [link](https://www.youtube.com/channel/UCVnJYdr91EZW8YvtMrxB1bg/videos) |
+| KarieraIT	| Katowice	| 2019-05-11	| 	|  |
+| infoShare	| Gdańsk	| 2019-05-08 - 2019-05-08	| [link](https://infoshare.pl/)	| [link](https://www.youtube.com/user/infoSharePL/playlists) |
+| SegFault	| Łódź	| 2019-04-26	| [link](http://segfault.events/)	|  |
+| KarieraIT	| Rzeszów	| 2019-04-13	| 	|  |
+| 4Developers	| Warszawa	| 2019-04-08	| [link](https://4developers.org.pl/)	| [link](https://www.youtube.com/user/PROIDEAconferences/playlists?sort=dd&shelf_id=13&view=50) |
+| Boiling Frogs	| Wrocław	| 2019-03-30	| [link](https://2019.boilingfrogs.pl/)	| [link](https://www.youtube.com/channel/UCgUfIjfLvWmARsQ-d5gPzrw/videos) |
+| Wroc#	| Wrocław	| 2019-03-29	| [link](https://www.wrocsharp.com/)	| [link](https://www.youtube.com/channel/UCQBldPvCFyB7GECmEsXKBlw/videos) |
+| AzureDay Poland	| Warszawa	| 2019-03-29	| [link](http://azureday.pro/)	|  |
+| KarieraIT	| Łódź	| 2019-03-23	| 	|  |
+| SFI	| Kraków	| 2019-03-21 - 2019-03-23	| [link](https://sfi.pl/)	| [link](https://www.youtube.com/user/StudenckiFestiwalInf/videos) |
+| KarieraIT	| Warszawa	| 2019-03-16	| 	|  |
+| SegFault	| Gdańsk	| 2019-03-14 - 2019-03-15	| [link](http://segfault.events/)	| [link](https://www.youtube.com/channel/UCV38Do_3C5uVk3lWePkyxTA/videos) |
+| InfoMEET	| Kraków	| 2019-03-09	| [link](https://www.infomeet.pl/)	|  |
+| KarieraIT	| Gdańsk	| 2019-03-02	| 	|  |
+| Lambda Days	| Kraków	| 2019-02-21 - 2019-02-22	| [link](http://www.lambdadays.org/)	| [link](https://www.youtube.com/watch?v=RCU5WQDT8_8&list=PLWbHc_FXPo2jaxwnNB7KFEV7HYA0qHVxl) |
+| KarieraIT	| Wrocław	| 2019-02-16	| 	|  |
+| Pyrcode	| Poznań	| 2019-01-18	| [link](https://pyrcode.pl)	|  |
+| Dni Informatyki PK	| Kraków	| 2018-12-04	| [link](https://itad-pk.github.io/)	|  |
+| CoreDump	| Kraków	| 2018-11-26	| [link](http://coredump.events)	|  |
+| MakingSoftware	| Kraków	| 2018-11-17	| [link](http://www.makingsoftware.pl/)	| [link](https://www.youtube.com/channel/UCO2SsvexXR8TkLwjU08EMMA/videos) |
+| TestWarez	| Zakopane	| 2018-11-14	| [link](https://www.testwarez.pl/)	|  |
+| Test Dive	| Kraków	| 2018-10-18	| [link](http://www.testdive.pl/)	| [link](https://www.youtube.com/channel/UC-8YqwFBC15rMjJRzt3OY9A/videos) |
+| 4Developers	| Kraków	| 2018-10-15 | [link](https://krakow.4developers.org.pl/)	|  |
+| {j}dd	| Kraków	| 2018-10-08 | [link](https://www.jdd.org.pl)	|  |
+| Programistok	| Białystok	| 2018-09-28	| [link](http://programistok.org/)	| [link](https://www.youtube.com/user/programistok/videos) |
+| BBQ4IT	| Bielsko Biała	| 2018-09-07	| [link](http://bbq4.it/)	|  |
+| Rzemiosło IT	| Rzeszów	| 2018-05-26	| [link](http://rzemioslo.it/)	| [link](https://www.youtube.com/channel/UCKuLHBJ7bMib3JcKN7eP5-Q/videos) |
 | 4Developers	| Gdańsk	| 	| [link](https://gdansk.4developers.org.pl/)	|  |
 | 4Developers	| Katowice	| 	| [link](https://katowice.4developers.org.pl/)	|  |
-| 4Developers	| Kraków	| 	| [link](https://krakow.4developers.org.pl/)	|  |
 | 4Developers	| Wrocław	| 	| [link](https://wroclaw.4developers.org.pl/)	|  |
 | 4Developers	| Łódź	| 	| [link](https://lodz.4developers.org.pl/)	|  |
 | Atmosphere Conference	| Warszawa	| 	| [link](https://atmosphere-conference.com/)	| [link](https://www.youtube.com/user/PROIDEAconferences/playlists?sort=dd&shelf_id=11&view=50) |
-| BBQ4IT	| Bielsko Biała	| 	| [link](http://bbq4.it/)	|  |
 | BSided Warsaw	| Warszawa	| 	| [link](https://securitybsides.pl/)	| [link](https://www.youtube.com/channel/UCexBIw_UJOz-H1PD9I9zkGw/videos) |
 | CodeEurope	| Kraków	| 	| [link](https://www.codeeurope.pl/)	| [link](https://www.youtube.com/channel/UChdVVEAilVHULlycMbqRpdg/videos) |
 | Confitura	| Warszawa	| 	| [link](https://2018.confitura.pl/)	| [link](https://www.youtube.com/user/confiturapl/videos) |
-| CoreDump	| Kraków	| 	| [link](http://coredump.events)	|  |
 | Dev#	| Gdańsk	| 	| [link]([link](http://devsharp.pl/))	|  |
-| Dni Informatyki PK	| Kraków	| 	| [link](https://itad-pk.github.io/)	|  |
 | DoIT	| Wrocław	| 	| [link](http://doit-conf.pl/)	|  |
 | DotNETConfPL	| Internet	| 	| [link](https://dotnetconf.pl/)	| [link](https://www.youtube.com/channel/UCs3oPPpRdETQTsxVF-Wvqbg/videos) |
 | Dotnetos	| Warszawa	| 	| [link](https://dotnetos.org/)	|  |
@@ -48,17 +54,11 @@
 | Get.NET	| Łódź	| 	| [link](https://konferencjaget.net/pl/lodz)	|  |
 | Get.NET	| Gdańsk	| 	| [link](https://konferencjaget.net/pl/gdansk)	|  |
 | Greenfield Conference	| Zielona Góra	| 	| [link](http://greenfieldconf.pl/)	| [link](https://www.youtube.com/channel/UChG7hsrjUYyYG13AkSIfQIw/videos) |
-| InfoMEET	| Kraków	| 	| [link](https://www.infomeet.pl/)	|  |
 | InfoMEET	| Wrocław	| 	| [link](https://www.infomeet.pl/)	|  |
 | JS Poland	| Warszawa	| 	| [link](https://js-poland.pl)	|  |
 | Lubelskie Dni Informatyki	| Lublin	| 	| [link](https://ldi.org.pl/)	|  |
-| MakingSoftware	| Kraków	| 	| [link](http://www.makingsoftware.pl/)	| [link](https://www.youtube.com/channel/UCO2SsvexXR8TkLwjU08EMMA/videos) |
 | MCE Conference	| Warszawa	| 	| [link](https://2018.mceconf.com/)	| [link](https://www.youtube.com/channel/UCVmsyhkifdHTomiVlA11FgQ/playlists) |
-| Programistok	| Białystok	| 	| [link](http://programistok.org/)	| [link](https://www.youtube.com/user/programistok/videos) |
-| Rzemiosło IT	| Rzeszów	| 	| [link](http://rzemioslo.it/)	| [link](https://www.youtube.com/channel/UCKuLHBJ7bMib3JcKN7eP5-Q/videos) |
 | Security PWNing Conference | Warszawa |  | [link](https://www.instytutpwn.pl/konferencja/pwning/)   |
 | SegFault	| Warszawa	| 	| [link](http://segfault.events/)	|  |
 | SegFault	| Wrocław	| 	| [link](http://segfault.events/)	|  |
-| Test Dive	| Kraków	| 	| [link](http://www.testdive.pl/)	| [link](https://www.youtube.com/channel/UC-8YqwFBC15rMjJRzt3OY9A/videos) |
-| TestWarez	| Zakopane	| 	| [link](https://www.testwarez.pl/)	|  |
 | Warszawskie Dni Informatyki	| Warszawa	| 	| [link](https://warszawskiedniinformatyki.pl/)	|  |


### PR DESCRIPTION
- zmiana nazwy z "Nastepne" na "Data" - w ten sposób można dodawać daty do byłych konferencji - przydatne, bo można się spodziewać kiedy będzie następna edycja
- odwróciłem sortowanie - dziala również dla byłych konferencji
- dodałem daty dla konferencji w przeszłości